### PR TITLE
Remove 'AllowSupplementaryGroups' option

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -252,7 +252,6 @@ class clamav::params {
   }
 
   $freshclam_default_options = {
-    'AllowSupplementaryGroups' => false,
     'Bytecode'                 => true,
     'Checks'                   => '24',
     'CompressLocalDatabase'    => 'no',


### PR DESCRIPTION
This isn't supported in all installations of ClamAV, remove it from the defaults